### PR TITLE
Move `haml` to devDependencies from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   },
   "homepage": "https://www.npmjs.com/package/haml-haml-loader",
   "dependencies": {
-    "haml": "^0.4.3",
     "loader-utils": "0.2.x"
+  },
+  "devDependencies": {
+    "haml": "^0.4.3"
   }
 }


### PR DESCRIPTION
I think it's a common practice for other webpack loaders, that you have to include on your own your `haml` or `less` or `typescript` packages anyway in your app's package.json (they are not inherited automatically from the loaders).
